### PR TITLE
Switched order between twipsy and popover in bootstrap

### DIFF
--- a/ptah/static/__init__.py
+++ b/ptah/static/__init__.py
@@ -30,10 +30,10 @@ ptah.library(
           'ptah:static/bootstrap/js/bootstrap-buttons.js',
           'ptah:static/bootstrap/js/bootstrap-dropdown.js',
           'ptah:static/bootstrap/js/bootstrap-modal.js',
-          'ptah:static/bootstrap/js/bootstrap-popover.js',
           'ptah:static/bootstrap/js/bootstrap-scrollspy.js',
           'ptah:static/bootstrap/js/bootstrap-tabs.js',
-          'ptah:static/bootstrap/js/bootstrap-twipsy.js'),
+          'ptah:static/bootstrap/js/bootstrap-twipsy.js',
+          'ptah:static/bootstrap/js/bootstrap-popover.js'),
     type="js",
     require="jquery")
 


### PR DESCRIPTION
Hi,

In the Popovers section it says: "NOTICE You must include the bootstrap-twipsy.js file before bootstrap-popover.js."

http://twitter.github.com/bootstrap/javascript.html

/Magnus
