### PR TITLE
docs: Fix simple typo, heirarchy -> hierarchy

### DIFF
--- a/docs/content.rst
+++ b/docs/content.rst
@@ -64,7 +64,7 @@ following:
   
   - Automatically generated Add/Edit forms
   
-  - Models will be available in Application content heirarchy
+  - Models will be available in Application content hierarchy
 
 
 Why Not Subclass from Content?

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -8,7 +8,7 @@ Ptah aims to provide a framework which makes low level choices for developers so
 
 Ptah is a framework, an implementation and set of opinions around the Pyramid web framework.  
 
-Ptah, like Pyramid, supports both URL dispatch, traversal.  Unlike Pyramid it provides a data model, content heirarchy,  form library, and high level security primitives (permissions, roles, and principals).  Any of this is additional to Pyramid and augements your application.
+Ptah, like Pyramid, supports both URL dispatch, traversal.  Unlike Pyramid it provides a data model, content hierarchy,  form library, and high level security primitives (permissions, roles, and principals).  Any of this is additional to Pyramid and augements your application.
 
 Where does Pyramid and Ptah differ?
 -----------------------------------

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -75,7 +75,7 @@ ApplicationFactory is a start-up time configuration which specifies
 a place in your URL to define where you want to mount an Application.
 You must have at least one ApplicationFactory call or else you will be unable
 to use the CMS.  The ApplicationFactory will return the ApplicationRoot based
-on where you `mount` the Application into your heirarchy.
+on where you `mount` the Application into your hierarchy.
 
   e.g.::
 

--- a/docs/rest.rst
+++ b/docs/rest.rst
@@ -9,7 +9,7 @@ You will need curl and ptah running for this example.
 
 Overview
 --------
-REST API is flat.  If your content participates in heirarchy the system will
+REST API is flat.  If your content participates in hierarchy the system will
 take this into account when computing security.
 
 Note that in the following values for __link__, __uri__ will be different in


### PR DESCRIPTION
There is a small typo in docs/content.rst, docs/faq.rst, docs/overview.rst, docs/rest.rst.

Should read `hierarchy` rather than `heirarchy`.

